### PR TITLE
Blind roll

### DIFF
--- a/module/actor/base-actor-sheet.js
+++ b/module/actor/base-actor-sheet.js
@@ -24,6 +24,9 @@ export class HarnMasterBaseActorSheet extends ActorSheet {
             config: CONFIG.HM3
         };
 
+        data.isGM = game.user.isGM;
+        data.strictMode = game.settings.get('hm3', 'strictGmMode');
+        data.hasRwPermission = data.isGM || !data.strictMode;
         data.isGridDistanceUnits = game.settings.get('hm3', 'distanceUnits') === 'grid';
         data.customSunSign = game.settings.get('hm3', 'customSunSign');
         data.actor = foundry.utils.deepClone(this.actor);

--- a/module/config.js
+++ b/module/config.js
@@ -1334,3 +1334,5 @@ HM3.itemLabels = {
     armorlocation: 'Armor Location',
     trait: 'Trait'
 };
+
+HM3.blindRolls = ['Awareness', 'Eyesight', 'Hearing', 'Smell', 'Weatherlore'];

--- a/module/hm3.js
+++ b/module/hm3.js
@@ -18,6 +18,8 @@ import {registerSystemSettings} from './settings.js';
 Hooks.once('init', async function () {
     console.log(`HM3 | Initializing the HM3 Game System\n${HM3.ASCII}`);
 
+    // CONFIG.debug.hooks = true;
+
     game.hm3 = {
         HarnMasterActor,
         HarnMasterItem,
@@ -156,7 +158,8 @@ Hooks.once('init', async function () {
                 }).render(true);
             },
             condition: (html) => {
-                return game.user.isGM;
+                const actor = game.actors.get(html.data('documentId'));
+                return game.user.isGM && actor?.system?.bioImage;
             }
         });
     });
@@ -165,8 +168,20 @@ Hooks.once('init', async function () {
 Hooks.on('renderChatMessage', (app, html, data) => {
     // Display action buttons
     combat.displayChatActionButtons(app, html, data);
+
+    console.log('visible: ' + app.isContentVisible + ' ' + app.visible);
+    if (html[0].innerHTML.includes('hm3 chat-card') && app.blind && !game.user.isGM) {
+        const nodes = html[0].childNodes[3].childNodes[1];
+        nodes.childNodes[3].innerText = app.blind ? 'Blind GM Roll' : 'GM Roll';
+        nodes.childNodes[5].remove();
+        nodes.childNodes[5].remove();
+        nodes.childNodes[5].remove();
+        nodes.childNodes[5].remove();
+    }
 });
+
 Hooks.on('renderChatLog', (app, html, data) => HarnMasterActor.chatListeners(html));
+
 Hooks.on('renderChatPopout', (app, html, data) => HarnMasterActor.chatListeners(html));
 
 /**

--- a/module/hm3.js
+++ b/module/hm3.js
@@ -169,10 +169,10 @@ Hooks.on('renderChatMessage', (app, html, data) => {
     // Display action buttons
     combat.displayChatActionButtons(app, html, data);
 
-    console.log('visible: ' + app.isContentVisible + ' ' + app.visible);
+    // if blind Roll Mode, remove info from Chat Card
     if (html[0].innerHTML.includes('hm3 chat-card') && app.blind && !game.user.isGM) {
         const nodes = html[0].childNodes[3].childNodes[1];
-        nodes.childNodes[3].innerText = app.blind ? 'Blind GM Roll' : 'GM Roll';
+        nodes.childNodes[3].innerText = 'Blind GM Roll';
         nodes.childNodes[5].remove();
         nodes.childNodes[5].remove();
         nodes.childNodes[5].remove();

--- a/module/macros.js
+++ b/module/macros.js
@@ -230,6 +230,7 @@ export async function skillRoll(itemName, noDialog = false, myActor = null) {
 
     const stdRollData = {
         type: `skill-${item.name}`,
+        skill: `${item.name}`,
         label: `${item.name} Skill Test`,
         target: item.system.effectiveMasteryLevel,
         notesData: {
@@ -269,6 +270,7 @@ export async function castSpellRoll(itemName, noDialog = false, myActor = null) 
 
     const stdRollData = {
         type: `spell-${item.name}`,
+        skill: `${item.name}`,
         label: `Casting ${item.name}`,
         target: item.system.effectiveMasteryLevel,
         notesData: {
@@ -311,6 +313,7 @@ export async function invokeRitualRoll(itemName, noDialog = false, myActor = nul
 
     const stdRollData = {
         type: `invocation-${item.name}`,
+        skill: `${item.name}`,
         label: `Invoking ${item.name} Ritual`,
         target: item.system.effectiveMasteryLevel,
         notesData: {
@@ -353,6 +356,7 @@ export async function usePsionicRoll(itemName, noDialog = false, myActor = null)
 
     const stdRollData = {
         type: `psionic-${item.name}`,
+        skill: `${item.name}`,
         label: `Using ${item.name} Talent`,
         target: item.system.effectiveMasteryLevel,
         notesData: {
@@ -409,6 +413,7 @@ export async function testAbilityD6Roll(ability, noDialog = false, myActor = nul
 
     const stdRollData = {
         type: `${ability}-d6`,
+        skill: `${ability[0].toUpperCase()}${ability.slice(1)}`,
         label: `d6 ${ability[0].toUpperCase()}${ability.slice(1)} Roll`,
         target: actorInfo.actor.system.abilities[ability].effective,
         numdice: 3,
@@ -455,6 +460,7 @@ export async function testAbilityD100Roll(ability, noDialog = false, myActor = n
 
     const stdRollData = {
         type: `${ability}-d100`,
+        skill: `${ability[0].toUpperCase()}${ability.slice(1)}`,
         label: `d100 ${ability[0].toUpperCase()}${ability.slice(1)} Roll`,
         target: Math.max(5, actorInfo.actor.system.abilities[ability].effective * multiplier),
         notesData: {},

--- a/module/settings.js
+++ b/module/settings.js
@@ -125,4 +125,13 @@ export const registerSystemSettings = function () {
         default: false,
         type: Boolean
     });
+
+    game.settings.register('hm3', 'blindGmMode', {
+        name: 'NEW Blind GM Mode',
+        hint: 'If selected, some skill rolls (such as Awareness, Hearing, Weatherlore, ...) are handled as Blind GM Roll regardless of the Roll Mode setting.',
+        scope: 'world',
+        config: true,
+        default: false,
+        type: Boolean
+    });
 };


### PR DESCRIPTION
The Roll Mode was not used - all rolls were public.
Furthermore, a new setting was added to consider some skills automatically as Blind GM Roll such as Awareness, Hearing, etc. Users do not need to change the roll mode anymore when rolling a secret skill roll. 